### PR TITLE
Plugin name import fixed

### DIFF
--- a/sentry_cfml/plugin.py
+++ b/sentry_cfml/plugin.py
@@ -1,4 +1,4 @@
-import sentry_pluginname
+import sentry_cfml
 from sentry.plugins import Plugin
 
 

--- a/sentry_cfml/plugin.py
+++ b/sentry_cfml/plugin.py
@@ -6,7 +6,7 @@ class CFMLPlugin(Plugin):
     title = 'Sentry CFML'
     slug = 'sentry-cfml'
     description = 'A plugin for CFML that adds a custom interface specific to request variables used in CFML'
-    version = sentry_pluginname.VERSION
+    version = sentry_cfml.VERSION
 
     author = 'Jay McEntire'
     author_url = 'https://github.com/jmacul2/sentry-cfml'


### PR DESCRIPTION
Hi there,

The plugin name import is still the boilerplate code from the documentation, causing an error when trying to load the plugin after installation. I've made the changes and tested without further errors.

Cheers,
Neil
