### PR TITLE
'Cookies' is not defined error

### DIFF
--- a/sentry_cfml/interfaces.py
+++ b/sentry_cfml/interfaces.py
@@ -74,7 +74,7 @@ class CFMLHttp(Interface):
             context.update({
                 'application': self.application,
                 'sessions': self.sessions,
-                'cookies': cookies,
+                'cookies': self.cookies,
                 'cgi': self.cgi,
             })
         


### PR DESCRIPTION
'Error processing 'to_html' on 'CFMLHttp': global name 'cookies' is not defined'

```
Error processing 'to_html' on 'CFMLHttp': global name 'cookies' is not defined
Traceback (most recent call last):
  File "/var/www/sentry/local/lib/python2.7/site-packages/sentry/utils/safe.py", line 16, in safe_execute
    result = func(*args, **kwargs)
  File "/var/www/sentry/src/sentry-cfml/sentry_cfml/interfaces.py", line 77, in to_html
    'cookies': cookies,
NameError: global name 'cookies' is not defined
```

This has been fixed in this commit -- I think. Python isn't a language I'm normally in.
